### PR TITLE
Fix systemd system-unit to basic.target

### DIFF
--- a/enter-systemd-namespace
+++ b/enter-systemd-namespace
@@ -24,7 +24,7 @@ if ! command -v /usr/bin/unshare > /dev/null; then
     exit 1
 fi
 
-SYSTEMD_EXE="/lib/systemd/systemd --system-unit=basic.target"
+SYSTEMD_EXE="/lib/systemd/systemd --unit=basic.target"
 SYSTEMD_PID="$(ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')"
 if [ -z "$SYSTEMD_PID" ]; then
     "$DAEMONIZE" /usr/bin/unshare --fork --pid --mount-proc bash -c 'export container=wsl; mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc; exec '"$SYSTEMD_EXE"

--- a/start-systemd-namespace
+++ b/start-systemd-namespace
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-SYSTEMD_EXE="/lib/systemd/systemd --system-unit=basic.target"
+SYSTEMD_EXE="/lib/systemd/systemd --unit=basic.target"
 SYSTEMD_PID="$(ps -eo pid=,args= | awk '$2" "$3=="'"$SYSTEMD_EXE"'" {print $1}')"
 if [ "$LOGNAME" != "root" ] && ( [ -z "$SYSTEMD_PID" ] || [ "$SYSTEMD_PID" != "1" ] ); then
     export | sed -e 's/^declare -x //;/^IFS=".*[^"]$/{N;s/\n//}' | \


### PR DESCRIPTION
* Systemd was being incorrectly started with multi-user.target as the system unit. Change the start command to correctly start the basic.target instead.
* Fixes #28

Signed-off-by: Daniel Llewellyn <diddledan@ubuntu.com>